### PR TITLE
AreablockDataType: Remove _editableType and _editableName fields

### DIFF
--- a/src/GraphQL/DocumentElementType/AreablockDataType.php
+++ b/src/GraphQL/DocumentElementType/AreablockDataType.php
@@ -33,22 +33,6 @@ class AreablockDataType extends ObjectType
             [
                 'name' => 'document_editableAreablock_data',
                 'fields' => [
-                    '_editableType' => [
-                        'type' => Type::string(),
-                        'resolve' => static function ($value = null, $args = [], $context = [], ?ResolveInfo $resolveInfo = null) {
-                            if ($value) {
-                                return $value->getType();
-                            }
-                        },
-                    ],
-                    '_editableName' => [
-                        'type' => Type::string(),
-                        'resolve' => static function ($value = null, $args = [], $context = [], ?ResolveInfo $resolveInfo = null) {
-                            if ($value) {
-                                return $value->getName();
-                            }
-                        },
-                    ],
                     'key' => [
                         'type' => Type::string(),
                         'resolve' => static function ($value = null, $args = [], $context = [], ?ResolveInfo $resolveInfo = null) {


### PR DESCRIPTION
Removed the '_editableType' and '_editableName' fields from the AreablockDataType configuration.

If you use these fields, an internal error occurs.

`Call to a member function getType() on array`
`Call to a member function getName() on array`