### PR TITLE
Fix relations to object folder

### DIFF
--- a/src/GraphQL/ClassTypeDefinitions.php
+++ b/src/GraphQL/ClassTypeDefinitions.php
@@ -60,7 +60,7 @@ class ClassTypeDefinitions
     public static function get($class)
     {
         $className = is_string($class) ? $class : $class->getName();
-        $result = self::$definitions[$className];
+        $result = self::$definitions[$className] ?? null;
         if (!$result) {
             throw new ClientSafeException('type definition ' . $className . ' not found');
         }

--- a/src/GraphQL/DataObjectType/AbstractRelationsType.php
+++ b/src/GraphQL/DataObjectType/AbstractRelationsType.php
@@ -128,9 +128,11 @@ abstract class AbstractRelationsType extends UnionType
     {
         if ($element) {
             if ($element['__elementType'] == 'object') {
-                $type = ClassTypeDefinitions::get($element['__elementSubtype']);
+                if ($element['__elementSubtype'] === 'folder') {
+                    return $this->getGraphQlService()->getDataObjectTypeDefinition('_object_folder');
+                }
 
-                return $type;
+                return ClassTypeDefinitions::get($element['__elementSubtype']);
             } elseif ($element['__elementType'] == 'asset') {
                 return  $this->getGraphQlService()->buildAssetType('asset');
             } elseif ($element['__elementType'] == 'document') {

--- a/src/GraphQL/General/AnyTargetType.php
+++ b/src/GraphQL/General/AnyTargetType.php
@@ -84,9 +84,11 @@ class AnyTargetType extends UnionType
     {
         if ($element) {
             if ($element['__elementType'] == 'object') {
-                $type = ClassTypeDefinitions::get($element['__elementSubtype']);
+                if ($element['__elementSubtype'] === 'folder') {
+                    return $this->getGraphQlService()->getDataObjectTypeDefinition('_object_folder');
+                }
 
-                return $type;
+                return ClassTypeDefinitions::get($element['__elementSubtype']);
             } elseif ($element['__elementType'] == 'asset') {
                 return  $this->getGraphQlService()->buildAssetType('asset');
             } elseif ($element['__elementType'] == 'document') {

--- a/src/GraphQL/PropertyType/ObjectsType.php
+++ b/src/GraphQL/PropertyType/ObjectsType.php
@@ -70,9 +70,11 @@ class ObjectsType extends UnionType
     {
         if ($element) {
             if ($element['__elementType'] == 'object') {
-                $type = ClassTypeDefinitions::get($element['__elementSubtype']);
+                if ($element['__elementSubtype'] === 'folder') {
+                    return $this->getGraphQlService()->getDataObjectTypeDefinition('_object_folder');
+                }
 
-                return $type;
+                return ClassTypeDefinitions::get($element['__elementSubtype']);
             } elseif ($element['__elementType'] == 'asset') {
                 return  $this->getGraphQlService()->buildAssetType('asset');
             } elseif ($element['__elementType'] == 'document') {


### PR DESCRIPTION
Error when you try to load a relation (editable relations, property) with a folder object value:
```
{
  "errors": [
    {
      "message": "Internal server error",
      "locations": [
        {
          "line": 142,
          "column": 3
        }
      ],
      "path": [
        "getDocument",
        "editables",
        79,
        "relations",
        0
      ],
      "extensions": {
        "debugMessage": "Warning: Undefined array key \"folder\"",
        "file": "/var/www/html/vendor/pimcore/data-hub/src/GraphQL/ClassTypeDefinitions.php",
        "line": 66,
        "trace": [
          {
            "file": "/var/www/html/vendor/pimcore/data-hub/src/GraphQL/General/AnyTargetType.php",
            "line": 90,
            "call": "Pimcore\\Bundle\\DataHubBundle\\GraphQL\\ClassTypeDefinitions::get('folder')"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1086,
            "call": "Pimcore\\Bundle\\DataHubBundle\\GraphQL\\General\\AnyTargetType::resolveType(instance of Pimcore\\Bundle\\DataHubBundle\\GraphQL\\ElementDescriptor(3), array(2), instance of GraphQL\\Type\\Definition\\ResolveInfo)"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 923,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeAbstractValue(GraphQLType: AnyTarget, instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(5), array(5), instance of Pimcore\\Bundle\\DataHubBundle\\GraphQL\\ElementDescriptor(3), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 783,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeValue(GraphQLType: AnyTarget, instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(5), array(5), instance of Pimcore\\Bundle\\DataHubBundle\\GraphQL\\ElementDescriptor(3), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1025,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeValueCatchingError(GraphQLType: AnyTarget, instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(5), array(5), instance of Pimcore\\Bundle\\DataHubBundle\\GraphQL\\ElementDescriptor(3), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 906,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeListValue(GraphQLType: [AnyTarget], instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(4), array(4), array(1), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 783,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeValue(GraphQLType: [AnyTarget], instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(4), array(4), array(1), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 663,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeValueCatchingError(GraphQLType: [AnyTarget], instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(4), array(4), array(1), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1372,
            "call": "GraphQL\\Executor\\ReferenceExecutor::resolveField(GraphQLType: document_editableRelations, instance of Pimcore\\Model\\Document\\Editable\\Relations, instance of ArrayObject(1), 'relations', array(4), array(4), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1304,
            "call": "GraphQL\\Executor\\ReferenceExecutor::executeFields(GraphQLType: document_editableRelations, instance of Pimcore\\Model\\Document\\Editable\\Relations, array(3), array(3), instance of ArrayObject(3), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1256,
            "call": "GraphQL\\Executor\\ReferenceExecutor::collectAndExecuteSubfields(GraphQLType: document_editableRelations, instance of ArrayObject(1), array(3), array(3), instance of Pimcore\\Model\\Document\\Editable\\Relations, array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1115,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeObjectValue(GraphQLType: document_editableRelations, instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(3), array(3), instance of Pimcore\\Model\\Document\\Editable\\Relations, array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 923,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeAbstractValue(GraphQLType: DocumentElement, instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(3), array(3), instance of Pimcore\\Model\\Document\\Editable\\Relations, array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 783,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeValue(GraphQLType: DocumentElement, instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(3), array(3), instance of Pimcore\\Model\\Document\\Editable\\Relations, array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1025,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeValueCatchingError(GraphQLType: DocumentElement, instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(3), array(3), instance of Pimcore\\Model\\Document\\Editable\\Relations, array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 906,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeListValue(GraphQLType: [DocumentElement], instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(2), array(2), array(106), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 783,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeValue(GraphQLType: [DocumentElement], instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(2), array(2), array(106), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 663,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeValueCatchingError(GraphQLType: [DocumentElement], instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(2), array(2), array(106), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1372,
            "call": "GraphQL\\Executor\\ReferenceExecutor::resolveField(GraphQLType: document_page, array(8), instance of ArrayObject(1), 'editables', array(2), array(2), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1304,
            "call": "GraphQL\\Executor\\ReferenceExecutor::executeFields(GraphQLType: document_page, array(8), array(1), array(1), instance of ArrayObject(6), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1256,
            "call": "GraphQL\\Executor\\ReferenceExecutor::collectAndExecuteSubfields(GraphQLType: document_page, instance of ArrayObject(1), array(1), array(1), array(8), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1115,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeObjectValue(GraphQLType: document_page, instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(1), array(1), array(8), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 923,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeAbstractValue(GraphQLType: Document, instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(1), array(1), array(8), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 783,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeValue(GraphQLType: Document, instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(1), array(1), array(8), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 663,
            "call": "GraphQL\\Executor\\ReferenceExecutor::completeValueCatchingError(GraphQLType: Document, instance of ArrayObject(1), instance of GraphQL\\Type\\Definition\\ResolveInfo, array(1), array(1), array(8), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 1372,
            "call": "GraphQL\\Executor\\ReferenceExecutor::resolveField(GraphQLType: Query, array(0), instance of ArrayObject(1), 'getDocument', array(1), array(1), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 310,
            "call": "GraphQL\\Executor\\ReferenceExecutor::executeFields(GraphQLType: Query, array(0), array(0), array(0), instance of ArrayObject(1), array(2))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php",
            "line": 249,
            "call": "GraphQL\\Executor\\ReferenceExecutor::executeOperation(instance of GraphQL\\Language\\AST\\OperationDefinitionNode, array(0))"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/Executor/Executor.php",
            "line": 184,
            "call": "GraphQL\\Executor\\ReferenceExecutor::doExecute()"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/GraphQL.php",
            "line": 164,
            "call": "GraphQL\\Executor\\Executor::promiseToExecute(instance of GraphQL\\Executor\\Promise\\Adapter\\SyncPromiseAdapter, instance of GraphQL\\Type\\Schema, instance of GraphQL\\Language\\AST\\DocumentNode, array(0), array(2), array(1), null, null)"
          },
          {
            "file": "/var/www/html/vendor/webonyx/graphql-php/src/GraphQL.php",
            "line": 98,
            "call": "GraphQL\\GraphQL::promiseToExecute(instance of GraphQL\\Executor\\Promise\\Adapter\\SyncPromiseAdapter, instance of GraphQL\\Type\\Schema, '...', array(0), array(2), array(1), null, null, null)"
          },
          {
            "file": "/var/www/html/vendor/pimcore/data-hub/src/Controller/WebserviceController.php",
            "line": 200,
            "call": "GraphQL\\GraphQL::executeQuery(instance of GraphQL\\Type\\Schema, '...', array(0), array(2), array(1), null, null, null)"
          },
          {
            "file": "/var/www/html/vendor/symfony/http-kernel/HttpKernel.php",
            "line": 163,
            "call": "Pimcore\\Bundle\\DataHubBundle\\Controller\\WebserviceController::webonyxAction(instance of Pimcore\\Bundle\\DataHubBundle\\GraphQL\\Service, instance of Pimcore\\Localization\\LocaleService, instance of Pimcore\\Model\\Factory, instance of Symfony\\Component\\HttpFoundation\\Request, instance of Pimcore\\Helper\\LongRunningHelper)"
          },
          {
            "file": "/var/www/html/vendor/symfony/http-kernel/HttpKernel.php",
            "line": 75,
            "call": "Symfony\\Component\\HttpKernel\\HttpKernel::handleRaw(instance of Symfony\\Component\\HttpFoundation\\Request, 1)"
          },
          {
            "file": "/var/www/html/vendor/symfony/http-kernel/Kernel.php",
            "line": 202,
            "call": "Symfony\\Component\\HttpKernel\\HttpKernel::handle(instance of Symfony\\Component\\HttpFoundation\\Request, 1, true)"
          },
          {
            "file": "/var/www/html/public/index.php",
            "line": 36,
            "call": "Symfony\\Component\\HttpKernel\\Kernel::handle(instance of Symfony\\Component\\HttpFoundation\\Request)"
          }
        ]
      }
    }
  ],
  ...
}
```