### PR TITLE
Fix relations/properties pointing to document folders

### DIFF
--- a/src/GraphQL/DataObjectType/AbstractRelationsType.php
+++ b/src/GraphQL/DataObjectType/AbstractRelationsType.php
@@ -140,6 +140,10 @@ abstract class AbstractRelationsType extends UnionType
                 if ($document) {
                     $documentType = $document->getType();
                     $service = $this->getGraphQlService();
+                    if ($documentType === 'folder') {
+                        return $service->getDocumentTypeDefinition('_document_folder');
+                    }
+
                     //TODO maybe catch unsupported types for now ?
                     $typeDefinition = $service->getDocumentTypeDefinition('document_' . $documentType);
 

--- a/src/GraphQL/General/AnyDocumentTargetType.php
+++ b/src/GraphQL/General/AnyDocumentTargetType.php
@@ -62,6 +62,10 @@ class AnyDocumentTargetType extends UnionType
                 if ($document) {
                     $documentType = $document->getType();
                     $service = $this->getGraphQlService();
+                    if ($documentType === 'folder') {
+                        return $service->getDocumentTypeDefinition('_document_folder');
+                    }
+
                     $typeDefinition = $service->getDocumentTypeDefinition('document_' . $documentType);
 
                     return $typeDefinition;

--- a/src/GraphQL/General/AnyTargetType.php
+++ b/src/GraphQL/General/AnyTargetType.php
@@ -96,6 +96,10 @@ class AnyTargetType extends UnionType
                 if ($document) {
                     $documentType = $document->getType();
                     $service = $this->getGraphQlService();
+                    if ($documentType === 'folder') {
+                        return $service->getDocumentTypeDefinition('_document_folder');
+                    }
+
                     //TODO maybe catch unsupported types for now ?
                     $typeDefinition = $service->getDocumentTypeDefinition('document_' . $documentType);
 

--- a/src/GraphQL/PropertyType/ObjectsType.php
+++ b/src/GraphQL/PropertyType/ObjectsType.php
@@ -82,6 +82,10 @@ class ObjectsType extends UnionType
                 if ($document) {
                     $documentType = $document->getType();
                     $service = $this->getGraphQlService();
+                    if ($documentType === 'folder') {
+                        return $service->getDocumentTypeDefinition('_document_folder');
+                    }
+
                     $typeDefinition = $service->getDocumentTypeDefinition('document_' . $documentType);
 
                     return $typeDefinition;


### PR DESCRIPTION
### Bug

When a relation, an object/document property or an editable relation **targets a document folder**, the GraphQL query fails with:

```
unknown document type: document_folder   (GraphQL/Service.php, getDocumentTypeDefinition)
```

The `resolveType()` methods of the relation/property resolvers handle the `document` element type via `getDocumentTypeDefinition('document_' . $documentType)`. For a folder, $documentType is `folder` → `document_folder`, which is not a registered type (only `_document_folder` is). Any query that can resolve a document folder through such a field errors out.

### Fix

Add a folder guard returning the registered `_document_folder` type — mirroring the existing object-folder handling (`_object_folder`).

Affected resolvers:
- `src/GraphQL/DataObjectType/AbstractRelationsType.php`
- `src/GraphQL/General/AnyTargetType.php`
- `src/GraphQL/General/AnyDocumentTargetType.php`
- `src/GraphQL/PropertyType/ObjectsType.php`

`php -l` clean on all four files.