### PR TITLE
DocumentFolderType: use key instead of filename field

### DIFF
--- a/src/GraphQL/DocumentType/DocumentFolderType.php
+++ b/src/GraphQL/DocumentType/DocumentFolderType.php
@@ -47,7 +47,7 @@ class DocumentFolderType extends FolderType
                     'name' => 'id',
                     'type' => Type::id(),
                 ],
-                'filename' => Type::string(),
+                'key' => Type::string(),
                 'fullpath' => [
                     'type' => Type::string(),
                 ],


### PR DESCRIPTION
Document folders expose a `filename` field, but documents don't have a filename — that concept only exists for assets (`Asset::getFilename()`). Pimcore documents use a `key` path segment (`Document::getKey()`).

The `filename` field is a leftover copied from `AssetFolderType` and resolves to `null` for document folders. This replaces it with `key`, matching how `ObjectFolderType` defines its path segment (`'key' => Type::string()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)