### PR TITLE
Fix misleading and misspelled property/metadata key descriptions

### DIFF
--- a/src/GraphQL/AssetType/AssetFolderType.php
+++ b/src/GraphQL/AssetType/AssetFolderType.php
@@ -58,7 +58,8 @@ class AssetFolderType extends FolderType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'List of property key names to include (if omitted, all properties are returned).',
+                        'description' => 'List of property key names to include '
+                            . '(if omitted, all properties are returned).',
                     ],
                 ],
                 'resolve' => $elementResolver->resolveProperties(...),

--- a/src/GraphQL/AssetType/AssetFolderType.php
+++ b/src/GraphQL/AssetType/AssetFolderType.php
@@ -58,7 +58,7 @@ class AssetFolderType extends FolderType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'comma seperated list of key names',
+                        'description' => 'List of property key names to include (if omitted, all properties are returned).',
                     ],
                 ],
                 'resolve' => $elementResolver->resolveProperties(...),

--- a/src/GraphQL/AssetType/AssetType.php
+++ b/src/GraphQL/AssetType/AssetType.php
@@ -197,7 +197,8 @@ class AssetType extends ObjectType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'List of property key names to include (if omitted, all properties are returned).',
+                        'description' => 'List of property key names to include '
+                            . '(if omitted, all properties are returned).',
                     ],
                 ],
                 'resolve' => $elementResolver->resolveProperties(...),

--- a/src/GraphQL/AssetType/AssetType.php
+++ b/src/GraphQL/AssetType/AssetType.php
@@ -197,7 +197,7 @@ class AssetType extends ObjectType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'comma separated list of key names',
+                        'description' => 'List of property key names to include (if omitted, all properties are returned).',
                     ],
                 ],
                 'resolve' => $elementResolver->resolveProperties(...),

--- a/src/GraphQL/DataObjectType/ObjectFolderType.php
+++ b/src/GraphQL/DataObjectType/ObjectFolderType.php
@@ -78,7 +78,7 @@ class ObjectFolderType extends FolderType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'comma separated list of key names',
+                        'description' => 'List of property key names to include (if omitted, all properties are returned).',
                     ],
                 ],
                 'resolve' => $resolver->resolveProperties(...),

--- a/src/GraphQL/DataObjectType/ObjectFolderType.php
+++ b/src/GraphQL/DataObjectType/ObjectFolderType.php
@@ -78,7 +78,8 @@ class ObjectFolderType extends FolderType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'List of property key names to include (if omitted, all properties are returned).',
+                        'description' => 'List of property key names to include '
+                            . '(if omitted, all properties are returned).',
                     ],
                 ],
                 'resolve' => $resolver->resolveProperties(...),

--- a/src/GraphQL/DataObjectType/OpenDxpObjectType.php
+++ b/src/GraphQL/DataObjectType/OpenDxpObjectType.php
@@ -135,7 +135,8 @@ class OpenDxpObjectType extends ObjectType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'List of property key names to include (if omitted, all properties are returned).',
+                        'description' => 'List of property key names to include '
+                            . '(if omitted, all properties are returned).',
                     ],
                 ],
                 'resolve' => $resolver->resolveProperties(...),

--- a/src/GraphQL/DataObjectType/OpenDxpObjectType.php
+++ b/src/GraphQL/DataObjectType/OpenDxpObjectType.php
@@ -135,7 +135,7 @@ class OpenDxpObjectType extends ObjectType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'comma separated list of key names',
+                        'description' => 'List of property key names to include (if omitted, all properties are returned).',
                     ],
                 ],
                 'resolve' => $resolver->resolveProperties(...),

--- a/src/GraphQL/DocumentType/AbstractDocumentType.php
+++ b/src/GraphQL/DocumentType/AbstractDocumentType.php
@@ -80,7 +80,7 @@ abstract class AbstractDocumentType extends ObjectType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'comma seperated list of key names',
+                        'description' => 'List of property key names to include (if omitted, all properties are returned).',
                     ],
                 ],
                 'resolve' => $resolver->resolveProperties(...),

--- a/src/GraphQL/DocumentType/AbstractDocumentType.php
+++ b/src/GraphQL/DocumentType/AbstractDocumentType.php
@@ -80,7 +80,8 @@ abstract class AbstractDocumentType extends ObjectType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'List of property key names to include (if omitted, all properties are returned).',
+                        'description' => 'List of property key names to include '
+                            . '(if omitted, all properties are returned).',
                     ],
                 ],
                 'resolve' => $resolver->resolveProperties(...),

--- a/src/GraphQL/DocumentType/DocumentFolderType.php
+++ b/src/GraphQL/DocumentType/DocumentFolderType.php
@@ -59,7 +59,8 @@ class DocumentFolderType extends FolderType
                     'args' => [
                         'keys' => [
                             'type' => Type::listOf(Type::string()),
-                            'description' => 'List of property key names to include (if omitted, all properties are returned).',
+                            'description' => 'List of property key names to include '
+                                . '(if omitted, all properties are returned).',
                         ],
                     ],
                     'resolve' => $resolver->resolveProperties(...),

--- a/src/GraphQL/DocumentType/DocumentFolderType.php
+++ b/src/GraphQL/DocumentType/DocumentFolderType.php
@@ -59,7 +59,7 @@ class DocumentFolderType extends FolderType
                     'args' => [
                         'keys' => [
                             'type' => Type::listOf(Type::string()),
-                            'description' => 'comma seperated list of key names',
+                            'description' => 'List of property key names to include (if omitted, all properties are returned).',
                         ],
                     ],
                     'resolve' => $resolver->resolveProperties(...),

--- a/src/GraphQL/SharedType/HotspotHotspotType.php
+++ b/src/GraphQL/SharedType/HotspotHotspotType.php
@@ -58,7 +58,8 @@ class HotspotHotspotType extends ObjectType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'List of metadata key names to include (if omitted, all entries are returned).',
+                        'description' => 'List of metadata key names to include '
+                            . '(if omitted, all entries are returned).',
                     ],
                 ],
                 'resolve' => $resolver->resolveMetadata(...),

--- a/src/GraphQL/SharedType/HotspotHotspotType.php
+++ b/src/GraphQL/SharedType/HotspotHotspotType.php
@@ -58,7 +58,7 @@ class HotspotHotspotType extends ObjectType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'comma seperated list of key names',
+                        'description' => 'List of metadata key names to include (if omitted, all entries are returned).',
                     ],
                 ],
                 'resolve' => $resolver->resolveMetadata(...),

--- a/src/GraphQL/SharedType/HotspotMarkerType.php
+++ b/src/GraphQL/SharedType/HotspotMarkerType.php
@@ -57,7 +57,7 @@ class HotspotMarkerType extends ObjectType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'comma seperated list of key names',
+                        'description' => 'List of metadata key names to include (if omitted, all entries are returned).',
                     ],
                 ],
                 'resolve' => $resolver->resolveMetadata(...),

--- a/src/GraphQL/SharedType/HotspotMarkerType.php
+++ b/src/GraphQL/SharedType/HotspotMarkerType.php
@@ -57,7 +57,8 @@ class HotspotMarkerType extends ObjectType
                 'args' => [
                     'keys' => [
                         'type' => Type::listOf(Type::string()),
-                        'description' => 'List of metadata key names to include (if omitted, all entries are returned).',
+                        'description' => 'List of metadata key names to include '
+                            . '(if omitted, all entries are returned).',
                     ],
                 ],
                 'resolve' => $resolver->resolveMetadata(...),


### PR DESCRIPTION
The `keys` argument on the `properties`/`metadata` fields is declared as `listOf(string)`, and the resolver matches the requested keys via `in_array()` — i.e. it expects an **array of key names**, not a comma-separated string. The current description (`comma seperated list of key names`) is therefore both misleading and misspelled.

Corrected the description text across all affected GraphQL types:
- Property fields (`resolveProperties`): AssetFolderType, AssetType, ObjectFolderType, OpenDxpObjectType, AbstractDocumentType, DocumentFolderType → *"List of property key names to include (if omitted, all properties are returned)."*
- Metadata fields (`resolveMetadata`): HotspotHotspotType, HotspotMarkerType → *"List of metadata key names to include (if omitted, all entries are returned)."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)