### PR TITLE
Fix undefined array key in document editables sort index for nested blocks

### DIFF
--- a/src/GraphQL/DocumentResolver/PageSnippet.php
+++ b/src/GraphQL/DocumentResolver/PageSnippet.php
@@ -94,7 +94,7 @@ class PageSnippet
             $blockName .= $parts[$i - 1]; // "areablock"
             $blockKey = $parts[$i]; // "1"
 
-            $block = $elements[$blockName];
+            $block = $elements[$blockName] ?? null;
             if ($block instanceof BlockInterface) {
                 $indices = $block->getData();
                 if ($block instanceof Areablock) {


### PR DESCRIPTION
### Bug

Querying the `editables` field of a `document_page` whose content contains a **deeply nested area-/block** structure fails with:

```
"message": "Internal server error",
"path": ["getDocument", "editables"],
"debugMessage": "Warning: Undefined array key \"content:3.contentblock\""
src/GraphQL/DocumentResolver/PageSnippet.php:97
```

Document meta resolves fine — only the `editables` field crashes, and only for documents with the nested structure (e.g. `content` areablock → `contentblock` → `content` → brick).

### Root cause

`getElementSortIndex()` walks the parent block names of a nested editable (e.g. `content:3.contentblock:1.content`) and looks each intermediate block name up in the document's editables map:

```php
$block = $elements[$blockName];
```

For a deeply nested editable an intermediate block key (e.g. `content:3.contentblock`) can be absent from the editables map, so this unguarded access raises a PHP 8 `Undefined array key` warning, which is escalated to an `Internal server error` for the entire `editables` field.

### Fix

Guard the lookup with `?? null`. The existing `if ($block instanceof BlockInterface)` already handles a missing block gracefully — that path segment simply contributes no sort index, exactly as when the block key is present but the index is not found.

```php
$block = $elements[$blockName] ?? null;
```

One-line, behaviour-preserving for the existing (resolvable) case. (Same fix submitted upstream as pimcore/data-hub#1112.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
