### PR TITLE
Fix undefined array key when a document image editable references a missing asset

### DIFF
--- a/src/GraphQL/DocumentElementType/ImageType.php
+++ b/src/GraphQL/DocumentElementType/ImageType.php
@@ -74,10 +74,12 @@ class ImageType extends ObjectType
                                 if ($value instanceof Image) {
                                     $data = $value->getData();
                                     if (isset($data['id'])) {
-                                        $data = new ElementDescriptor(Asset::getById($data['id']));
-                                        $result = $resolver->resolveImage($data, $args, $context, $resolveInfo);
+                                        $asset = Asset::getById($data['id']);
+                                        if ($asset instanceof Asset) {
+                                            $data = new ElementDescriptor($asset);
 
-                                        return $result;
+                                            return $resolver->resolveImage($data, $args, $context, $resolveInfo);
+                                        }
                                     }
                                 }
 


### PR DESCRIPTION
## Problem

When a document **image editable** stores an asset id whose asset no longer exists (deleted asset → dangling reference), `Asset::getById($data['id'])` returns `null`. The `image` field resolver still wraps that `null` in an `ElementDescriptor` and passes it to `HotspotType::resolveImage()`, which then reads `$value['id']` on the empty descriptor:

```
Warning: Undefined array key "id"
  src/GraphQL/Resolver/HotspotType.php  (resolveImage)
  ← src/GraphQL/DocumentElementType/ImageType.php  (image resolve)
```

With warnings promoted to exceptions this surfaces to clients as a generic **"Internal server error"** on the whole `getDocument` query — a single dangling image reference takes down the entire document response.

## Fix

Only build the `ElementDescriptor` and resolve the image when the referenced asset actually loads. If the asset is missing, the `image` field resolves to `null` (i.e. "no image"), exactly like an unset editable — no exception, the rest of the document still resolves.

Same class of hardening as the recent "undefined array key" editable fixes.