### PR TITLE
Improve RenderletType relation resolution and type field

### DIFF
--- a/doc/10_GraphQL/04_Query/01_Document_Queries.md
+++ b/doc/10_GraphQL/04_Query/01_Document_Queries.md
@@ -22,6 +22,7 @@
 * Pdf
 * Relation
 * Relations
+* Renderlet
 * Scheduled Block
 * Select
 * Table

--- a/src/GraphQL/DocumentElementType/RenderletType.php
+++ b/src/GraphQL/DocumentElementType/RenderletType.php
@@ -15,6 +15,7 @@
 
 namespace OpenDxp\Bundle\DataHubBundle\GraphQL\DocumentElementType;
 
+use Closure;
 use Exception;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -22,6 +23,7 @@ use GraphQL\Type\Definition\Type;
 use OpenDxp\Bundle\DataHubBundle\GraphQL\ElementDescriptor;
 use OpenDxp\Bundle\DataHubBundle\GraphQL\Service;
 use OpenDxp\Model\Document\Editable\Renderlet;
+use OpenDxp\Model\Element;
 
 class RenderletType extends ObjectType
 {
@@ -42,56 +44,60 @@ class RenderletType extends ObjectType
                 'fields' => [
                     '_editableType' => [
                         'type' => Type::string(),
-                        'resolve' => static function ($value = null, $args = [], $context = [], ?ResolveInfo $resolveInfo = null) {
-                            if ($value instanceof Renderlet) {
-                                return $value->getType();
-                            }
-                        },
+                        'resolve' => self::resolveRenderlet(static fn (Renderlet $r) => $r->getType()),
                     ],
                     '_editableName' => [
                         'type' => Type::string(),
-                        'resolve' => static function ($value = null, $args = [], $context = [], ?ResolveInfo $resolveInfo = null) {
-                            if ($value instanceof Renderlet) {
-                                return $value->getName();
-                            }
-                        },
+                        'resolve' => self::resolveRenderlet(static fn (Renderlet $r) => $r->getName()),
                     ],
                     'id' => [
                         'type' => Type::int(),
-                        'resolve' => static function ($value = null, $args = [], $context = [], ?ResolveInfo $resolveInfo = null) {
-                            if ($value instanceof Renderlet) {
-                                return $value->getId();
-                            }
-                        },
+                        'resolve' => self::resolveRenderlet(static fn (Renderlet $r) => $r->getId()),
                     ],
                     'type' => [
                         'type' => Type::string(),
-                        'resolve' => static function ($value = null, $args = [], $context = [], ?ResolveInfo $resolveInfo = null) {
-                            if ($value instanceof Renderlet) {
-                                return $value->getType();
-                            }
-                        },
+                        'resolve' => self::resolveRenderlet(
+                            static fn (Renderlet $r) => $r->getData()['type'] ?? null,
+                        ),
                     ],
                     'subtype' => [
                         'type' => Type::string(),
-                        'resolve' => static function ($value = null, $args = [], $context = [], ?ResolveInfo $resolveInfo = null) {
-                            if ($value instanceof Renderlet) {
-                                return $value->getSubtype();
-                            }
-                        },
+                        'resolve' => self::resolveRenderlet(static fn (Renderlet $r) => $r->getSubtype()),
                     ],
                     'relation' => [
                         'type' => $anyTargetType,
-                        'resolve' => static function ($value = null, $args = [], $context = [], ?ResolveInfo $resolveInfo = null) use ($graphQlService) {
-                            if ($value instanceof Renderlet) {
-                                $target = $value->getO();
-                                if ($target) {
-                                    $desc = new ElementDescriptor($target);
-                                    $graphQlService->extractData($desc, $target, $args, $context, $resolveInfo);
-
-                                    return $desc;
-                                }
+                        'resolve' => static function (
+                            $value = null,
+                            $args = [],
+                            $context = [],
+                            ?ResolveInfo $resolveInfo = null,
+                        ) use ($graphQlService) {
+                            if (!$value instanceof Renderlet) {
+                                return null;
                             }
+
+                            // getO() does not lazy-load and $o is stripped when the
+                            // document is serialized into the core cache, so resolve
+                            // the target explicitly (like Renderlet::frontend() does).
+                            $value->load();
+
+                            $target = $value->getO();
+                            if (!$target instanceof Element\ElementInterface) {
+                                return null;
+                            }
+
+                            // don't leak unpublished elements (Relation::getElement() filters these too)
+                            if (
+                                Element\Service::doHideUnpublished($target)
+                                && !Element\Service::isPublished($target)
+                            ) {
+                                return null;
+                            }
+
+                            $desc = new ElementDescriptor($target);
+                            $graphQlService->extractData($desc, $target, $args, $context, $resolveInfo);
+
+                            return $desc;
                         },
                     ],
                 ],
@@ -100,5 +106,21 @@ class RenderletType extends ObjectType
         }
 
         return self::$instance;
+    }
+
+    /**
+     * Wraps a field resolver so it only runs for a Renderlet editable.
+     *
+     * @param callable(Renderlet): mixed $resolver
+     */
+    private static function resolveRenderlet(callable $resolver): Closure
+    {
+        return static function ($value = null) use ($resolver) {
+            if ($value instanceof Renderlet) {
+                return $resolver($value);
+            }
+
+            return null;
+        };
     }
 }


### PR DESCRIPTION
Follow-up to #9:

- **relation**: call `load()` before `getO()`. `getO()` does not lazy-load and `$o` is stripped from the serialized document in the core cache, so cache-hit documents resolved `relation` to `null` despite a valid target.
- **relation**: filter unpublished targets, mirroring `Relation::getElement()`.
- **type**: expose the target's real element type via `getData()['type']` instead of `getType()`, which is hardcoded to `renderlet` and duplicated `_editableType`.
- extract a `resolveRenderlet()` helper for the simple editable fields.
- **doc**: add `Renderlet` to the supported page element types list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)