### PR TITLE
Make getDocument folder-safe (resolve document folders)

### DIFF
--- a/src/GraphQL/DocumentType/DocumentType.php
+++ b/src/GraphQL/DocumentType/DocumentType.php
@@ -80,7 +80,9 @@ class DocumentType extends UnionType
      */
     public function getTypes(): array
     {
-        return array_merge($this->types, $this->customTypes);
+        $folderType = $this->getGraphQlService()->getDocumentTypeDefinition('_document_folder');
+
+        return array_merge($this->types, [$folderType], $this->customTypes);
     }
 
     /**
@@ -112,6 +114,8 @@ class DocumentType extends UnionType
             return $this->hardlinkType;
         } elseif ($element instanceof Document\Snippet) {
             return $this->snippetType;
+        } elseif ($element instanceof Document\Folder) {
+            return $this->getGraphQlService()->getDocumentTypeDefinition('_document_folder');
         }
 
         return null;

--- a/src/GraphQL/General/AnyDocumentTargetType.php
+++ b/src/GraphQL/General/AnyDocumentTargetType.php
@@ -41,17 +41,9 @@ class AnyDocumentTargetType extends UnionType
      */
     public function getTypes(): array
     {
-        $types = [];
-
-        $service = $this->getGraphQlService();
-        $documentFolderType = $service->getDocumentTypeDefinition('_document_folder');
-
-        $types[] = $documentFolderType;
         $documentUnionType = $this->getGraphQlService()->getDocumentTypeDefinition('document');
-        $supportedDocumentTypes = $documentUnionType->getTypes();
-        $types = array_merge($types, $supportedDocumentTypes);
 
-        return $types;
+        return $documentUnionType->getTypes();
     }
 
     public function resolveType($element, $context, ResolveInfo $info)

--- a/src/GraphQL/General/AnyTargetType.php
+++ b/src/GraphQL/General/AnyTargetType.php
@@ -61,7 +61,9 @@ class AnyTargetType extends UnionType
             $types[] = $assetFolderType;
         }
 
-        if ($service->querySchemaEnabled('document_folder')) {
+        if ($service->querySchemaEnabled('document_folder') && !$service->querySchemaEnabled('document')) {
+            // The 'document' union already includes _document_folder; only add it
+            // separately when the document union itself is not merged below.
             $documentFolderType = $service->getDocumentTypeDefinition('_document_folder');
             $types[] = $documentFolderType;
         }


### PR DESCRIPTION
`getDocument(fullpath)` on a folder path currently fails: `DocumentType::resolveType` returns `null` for folders, so the `document` union cannot resolve the abstract type at runtime ("Abstract type Document must resolve to an Object type at runtime ... received null").

This adds the already-existing `_document_folder` type to the union (`getTypes`) and resolves it (`resolveType`), mirroring the folder guard already present in `AbstractRelationsType`, `ObjectsType` and `AnyDocumentTargetType`. No new type is introduced.

Verified against a real Pimcore install: before, `getDocument` on a folder path errors; after, it returns `document_folder`. Non-folder documents are unaffected.