### PR TITLE
Register _object_folder in relation/object union getTypes()

### DIFF
--- a/src/GraphQL/DataObjectType/AbstractRelationsType.php
+++ b/src/GraphQL/DataObjectType/AbstractRelationsType.php
@@ -100,6 +100,11 @@ abstract class AbstractRelationsType extends UnionType
                     if (is_array($className)) {
                         $className = $className['classes'];
                     }
+                    if ($className === 'folder') {
+                        $types[] = $this->getGraphQlService()->getDataObjectTypeDefinition('_object_folder');
+
+                        continue;
+                    }
                     $types[] = ClassTypeDefinitions::get($className);
                 }
             }

--- a/src/GraphQL/PropertyType/ObjectsType.php
+++ b/src/GraphQL/PropertyType/ObjectsType.php
@@ -49,6 +49,10 @@ class ObjectsType extends UnionType
             $types = array_merge($types, $objectTypes);
         }
 
+        if ($service->querySchemaEnabled('object_folder')) {
+            $types[] = $this->getGraphQlService()->getDataObjectTypeDefinition('_object_folder');
+        }
+
         if ($service->querySchemaEnabled('document')) {
             $documentUnionType = $this->getGraphQlService()->getDocumentTypeDefinition('document');
             $supportedDocumentTypes = $documentUnionType->getTypes();


### PR DESCRIPTION
resolveType() already routes object-folder targets to the special `_object_folder` type, but the union `getTypes()` methods never advertised it as a possible member type.

Two consequences:
- webonyx rejects a folder value with *"resolved to a type that is not a possible type"*.
- Because `Schema::getTypeMap()` builds the whole type graph eagerly on any query, an affected relation/property reachable in the schema makes **every** query fail with `type definition folder not found` (from `ClassTypeDefinitions::get('folder')`), not only queries that select the field.

Fixes:
- `AbstractRelationsType::getTypes()`: route the `'folder'` pseudo-class (a relation field that allows object folders) to `_object_folder`, mirroring the existing `resolveType()` branch.
- `ObjectsType::getTypes()`: register `_object_folder` under the same `querySchemaEnabled('object_folder')` guard already used by `AnyTargetType::getTypes()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)